### PR TITLE
🤖 Add dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "22:00"
+  open-pull-requests-limit: 15
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "22:00"
+  open-pull-requests-limit: 15


### PR DESCRIPTION
In this PR: 

- [x] Adds a  default `dependabot.yml` to templates†


† Seeing as we have either Rubygems and/or NPM in almost every project, the defaults include both. 

Default config is to run once a month at 9am Melbourne time. 